### PR TITLE
Fix page numbering and rank numbering

### DIFF
--- a/src/commands/leveling.rs
+++ b/src/commands/leveling.rs
@@ -131,8 +131,8 @@ pub async fn levels(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
     let mut iter = leaderboard.chunks(PAGE_SIZE);
 
     let page_num = match args.parse::<usize>() {
-        Ok(num) => num,
-        Err(_) => 1,
+        Ok(num) => num - 1,
+        Err(_) => 0,
     };
 
     let page = match iter.nth(page_num) {
@@ -146,15 +146,15 @@ pub async fn levels(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
                 e.title("Leaderboard");
                 e.description(format!(
                     "**Page {}:** {}-{} of {}",
-                    page_num.to_string(),
-                    PAGE_SIZE * (page_num - 1) + 1,
-                    PAGE_SIZE * page_num,
+                    (page_num + 1).to_string(),
+                    PAGE_SIZE * page_num + 1,
+                    PAGE_SIZE * (page_num + 1),
                     leaderboard.len()
                 ));
 
                 for (i, l) in page.iter().enumerate() {
                     e.field(
-                        format!("#{}: {}", i + 1, l.member.display_name()),
+                        format!("#{}: {}", PAGE_SIZE * page_num + i + 1, l.member.display_name()),
                         format!("{} Exp.\tLvl. {}\t{} Messages", l.xp, l.level, l.msg_count),
                         false,
                     );


### PR DESCRIPTION
**Issue Closed:** Fixes #31 

**Commands Added:** None

**Commands Removed:** None

**Features Added:** N/A

**Features Removed:** N/A

**Other Changes:** Fix page numbering and rank numbering

**Justification:** Page indexing starts from 0 but humans count from 1. Using `&levels` without a 
 page returned page "1" (the second page) and the rank numbers didn't respect which page they're on.
