### PR TITLE
Delete flag reaction when the message has been forwarded

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,7 @@ impl EventHandler for Handler {
                                 .await
                                 .unwrap();
                         }
+                        reaction.delete(&ctx.http).await.unwrap();
                     } else {
                         return;
                     }


### PR DESCRIPTION
**Issue Closed:** Closes #34 

**Commands Added:** None

**Commands Removed:** None

**Features Added:** Removes triggering reaction when a message has been forwarded to the mods

**Features Removed:** None

**Other Changes:** None

**Justification:** Because Cara mentioned something like this earlier today and we realized that this bot doesn't do this.

No this hasn't been tested yet (I don't want to hook this up to the live Redis DB and Redis is fighting with me in general... see #35 )